### PR TITLE
Fix/better conversion of control chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `ConvertTo-DifferenceString`
+  - Improve how control characters (ASCII values 0-31 and 127) are converted
+    to their corresponding Unicode representations in the Control Pictures
+    block to output printable versions.
+
 ## [0.3.0] - 2024-09-02
+
+### Added
 
 - Public commands:
   - `Invoke-PesterJob`

--- a/source/Public/ConvertTo-DifferenceString.ps1
+++ b/source/Public/ConvertTo-DifferenceString.ps1
@@ -189,6 +189,8 @@ function ConvertTo-DifferenceString
         "$($ColumnHeaderAnsi)-----                                           -----                   -----                                           -----$($ColumnHeaderResetAnsi)"
     }
 
+    $isHighlighted = $false
+
     # Loop through each byte in the arrays up to the maximum length
     for ($i = 0; $i -lt $maxLength; $i++)
     {
@@ -249,10 +251,6 @@ function ConvertTo-DifferenceString
             $diffChar = "$($HighlightStart)$diffChar$($HighlightEnd)"
 
             $isHighlighted = $true
-        }
-        else
-        {
-            $isHighlighted = $false
         }
 
         # Add to arrays

--- a/source/Public/ConvertTo-DifferenceString.ps1
+++ b/source/Public/ConvertTo-DifferenceString.ps1
@@ -79,7 +79,6 @@
 #>
 function ConvertTo-DifferenceString
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseBOMForUnicodeEncodedFile', '', Justification = 'This file is not intended to be saved as a Unicode-encoded file even though it has unicode characters, if that is a problem that can be re-evaluated.')]
     [CmdletBinding()]
     [OutputType([System.String])]
     param
@@ -174,10 +173,6 @@ function ConvertTo-DifferenceString
     $diffHexArray = @()
     $diffCharArray = @()
 
-    # Escape $HighlightStart and $HighlightEnd for regex matching
-    $escapedHighlightStart = [regex]::Escape($HighlightStart)
-    $escapedHighlightEnd = [regex]::Escape($HighlightEnd)
-
     # Output the labels if NoLabels is not specified
     if (-not $NoLabels)
     {
@@ -200,7 +195,7 @@ function ConvertTo-DifferenceString
         {
             $refByte = $referenceBytes[$i]
             $refHex = '{0:X2}' -f $refByte
-            $refChar = [char]$refByte
+            $refChar = if ($refByte -lt 32) { [char]($refByte + 0x2400) } elseif ($refByte -eq 127) { [char]0x2421 } else { [char]$refByte }
         }
         else
         {
@@ -213,7 +208,7 @@ function ConvertTo-DifferenceString
         {
             $diffByte = $differenceBytes[$i]
             $diffHex = '{0:X2}' -f $diffByte
-            $diffChar = [char]$diffByte
+            $diffChar = if ($diffByte -lt 32) { [char]($diffByte + 0x2400) } elseif ($diffByte -eq 127) { [char]0x2421 } else { [char]$diffByte }
         }
         else
         {
@@ -228,28 +223,13 @@ function ConvertTo-DifferenceString
             $refChar = "$($HighlightStart)$refChar$($HighlightEnd)"
             $diffHex = "$($HighlightStart)$diffHex$($HighlightEnd)"
             $diffChar = "$($HighlightStart)$diffChar$($HighlightEnd)"
+
+            $isHighlighted = $true
         }
-
-        # Replace control characters with their Unicode representations in the output
-        $refChar = $refChar`
-            -replace "`0", '␀' `
-            -replace "`a", '␇' `
-            -replace "`b", '␈' `
-            -replace "`t", '␉' `
-            -replace "`f", '␌' `
-            -replace "`r", '␍' `
-            -replace "`n", '␊' `
-            -replace "(?!$($escapedHighlightStart))(?!$($escapedHighlightEnd))`e", '␛'
-
-        $diffChar = $diffChar `
-            -replace "`0", '␀' `
-            -replace "`a", '␇' `
-            -replace "`b", '␈' `
-            -replace "`t", '␉' `
-            -replace "`f", '␌' `
-            -replace "`r", '␍' `
-            -replace "`n", '␊' `
-            -replace "(?!$($escapedHighlightStart))(?!$($escapedHighlightEnd))`e", '␛'
+        else
+        {
+            $isHighlighted = $false
+        }
 
         # Add to arrays
         $refHexArray += $refHex
@@ -283,8 +263,8 @@ function ConvertTo-DifferenceString
             $diffHexLine = ($diffHexArray -join ' ')
             $diffCharLine = ($diffCharArray -join '')
 
-            # Determine if the line was highlighted
-            $indicator = if ($refHexLine -match $escapedHighlightStart -or $diffHexLine -match $escapedHighlightStart)
+            # Output indicator depending if the line was highlighted or not.
+            $indicator = if ($isHighlighted)
             {
                 $NotEqualIndicator
             }

--- a/source/Public/ConvertTo-DifferenceString.ps1
+++ b/source/Public/ConvertTo-DifferenceString.ps1
@@ -156,13 +156,14 @@ function ConvertTo-DifferenceString
     $ColumnHeaderAnsi = ConvertTo-AnsiSequence -Value $ColumnHeaderAnsi
     $ColumnHeaderResetAnsi = ConvertTo-AnsiSequence -Value $ColumnHeaderResetAnsi
 
-    # Handle empty string or single character indicator
+    # Precompute padding the indicators outside the loop
     $NotEqualIndicator = $NotEqualIndicator.PadRight(2)
     $EqualIndicator = $EqualIndicator.PadRight(2)
 
     # Convert the strings to byte arrays using the specified encoding
-    $referenceBytes = ([System.Text.Encoding]::$EncodingType).GetBytes($ReferenceString)
-    $differenceBytes = ([System.Text.Encoding]::$EncodingType).GetBytes($DifferenceString)
+    $encoding = [System.Text.Encoding]::$EncodingType
+    $referenceBytes = $encoding.GetBytes($ReferenceString)
+    $differenceBytes = $encoding.GetBytes($DifferenceString)
 
     # Determine the maximum length of the two byte arrays
     $maxLength = [Math]::Max($referenceBytes.Length, $differenceBytes.Length)
@@ -195,7 +196,18 @@ function ConvertTo-DifferenceString
         {
             $refByte = $referenceBytes[$i]
             $refHex = '{0:X2}' -f $refByte
-            $refChar = if ($refByte -lt 32) { [char]($refByte + 0x2400) } elseif ($refByte -eq 127) { [char]0x2421 } else { [char]$refByte }
+            $refChar = if ($refByte -lt 32)
+            {
+                [System.Char] ($refByte + 0x2400)
+            }
+            elseif ($refByte -eq 127)
+            {
+                [System.Char] 0x2421
+            }
+            else
+            {
+                [System.Char] $refByte
+            }
         }
         else
         {
@@ -208,7 +220,18 @@ function ConvertTo-DifferenceString
         {
             $diffByte = $differenceBytes[$i]
             $diffHex = '{0:X2}' -f $diffByte
-            $diffChar = if ($diffByte -lt 32) { [char]($diffByte + 0x2400) } elseif ($diffByte -eq 127) { [char]0x2421 } else { [char]$diffByte }
+            $diffChar = if ($diffByte -lt 32)
+            {
+                [System.Char] ($diffByte + 0x2400)
+            }
+            elseif ($diffByte -eq 127)
+            {
+                [System.Char] 0x2421
+            }
+            else
+            {
+                [System.Char] $diffByte
+            }
         }
         else
         {

--- a/source/Public/ConvertTo-DifferenceString.ps1
+++ b/source/Public/ConvertTo-DifferenceString.ps1
@@ -149,6 +149,7 @@ function ConvertTo-DifferenceString
         $EncodingType = 'UTF8'
     )
 
+    # Get actual ANSI escape sequences if they weren't.
     $HighlightStart = ConvertTo-AnsiSequence -Value $HighlightStart
     $HighlightEnd = ConvertTo-AnsiSequence -Value $HighlightEnd
     $ReferenceLabelAnsi = ConvertTo-AnsiSequence -Value $ReferenceLabelAnsi
@@ -156,7 +157,7 @@ function ConvertTo-DifferenceString
     $ColumnHeaderAnsi = ConvertTo-AnsiSequence -Value $ColumnHeaderAnsi
     $ColumnHeaderResetAnsi = ConvertTo-AnsiSequence -Value $ColumnHeaderResetAnsi
 
-    # Precompute padding the indicators outside the loop
+    # Pre-pad indicators
     $NotEqualIndicator = $NotEqualIndicator.PadRight(2)
     $EqualIndicator = $EqualIndicator.PadRight(2)
 

--- a/source/en-US/Viscalyx.Common.strings.psd1
+++ b/source/en-US/Viscalyx.Common.strings.psd1
@@ -6,12 +6,6 @@
 #>
 
 ConvertFrom-StringData @'
-    ## Remove-History
-    Convert_PesterSyntax_ShouldProcessVerboseDescription = Converting the script file '{0}'.
-    Convert_PesterSyntax_ShouldProcessVerboseWarning = Are you sure you want to convert the script file '{0}'?
-    # This string shall not end with full stop (.) since it is used as a title of ShouldProcess messages.
-    Convert_PesterSyntax_ShouldProcessCaption = Convert script file
-
     ## New-SamplerGitHubReleaseTag
     New_SamplerGitHubReleaseTag_RemoteMissing = The remote '{0}' does not exist in the local git repository. Please add the remote before proceeding.
     New_SamplerGitHubReleaseTag_FailedFetchBranchFromRemote = Failed to fetch branch '{0}' from the remote '{1}'. Make sure the branch exists in the remote git repository and the remote is accessible.

--- a/tests/Unit/Public/ConvertTo-DifferenceString.tests.ps1
+++ b/tests/Unit/Public/ConvertTo-DifferenceString.tests.ps1
@@ -103,10 +103,15 @@ Describe '-join (ConvertTo-DifferenceString' {
         $result | Should -Match '31md'
     }
 
-    It 'Should handle special characters' {
+    It 'Should handle CR and LF special characters' {
         $result = -join (ConvertTo-DifferenceString -ReferenceString "Hello`n" -DifferenceString "Hello`r")
         $result | Should -Match '31m0A'
         $result | Should -Match '31m0D'
+    }
+
+    It 'Should handle DEL special characters' {
+        $result = -join (ConvertTo-DifferenceString -ReferenceString ('Hello' + [char] 127) -DifferenceString ('Hello' + [char] 127))
+        $result | Should -Match ([System.Char] 0x2421)
     }
 
     It 'Should use custom highlighting' {

--- a/tests/Unit/Public/ConvertTo-DifferenceString.tests.ps1
+++ b/tests/Unit/Public/ConvertTo-DifferenceString.tests.ps1
@@ -43,13 +43,13 @@ AfterAll {
 }
 
 Describe '-join (ConvertTo-DifferenceString' {
-    It 'should use custom labels' {
+    It 'Should use custom labels' {
         $result = -join (ConvertTo-DifferenceString -ReferenceString 'Hello' -DifferenceString 'Hallo' -ReferenceLabel 'Ref:' -DifferenceLabel 'Diff:')
         $result | Should -Match 'Ref:'
         $result | Should -Match 'Diff:'
     }
 
-    It 'should handle different encoding types' {
+    It 'Should handle different encoding types' {
         $result = -join (ConvertTo-DifferenceString -ReferenceString 'Hello' -DifferenceString 'Hallo' -EncodingType 'ASCII')
         $result | Should -Match '31m65'
         $result | Should -Match '31m61'
@@ -57,24 +57,24 @@ Describe '-join (ConvertTo-DifferenceString' {
         $result | Should -Match '31ma'
     }
 
-    It 'should exclude column header when NoColumnHeader is specified' {
+    It 'Should exclude column header when NoColumnHeader is specified' {
         $result = -join (ConvertTo-DifferenceString -ReferenceString 'Hello' -DifferenceString 'Hallo' -NoColumnHeader)
         $result | Should -Not -Match 'Bytes'
         $result | Should -Not -Match 'Ascii'
     }
 
-    It 'should exclude labels when NoLabels is specified' {
+    It 'Should exclude labels when NoLabels is specified' {
         $result = -join (ConvertTo-DifferenceString -ReferenceString 'Hello' -DifferenceString 'Hallo' -NoLabels)
         $result | Should -Not -Match 'Expected:'
         $result | Should -Not -Match 'But was:'
     }
 
-    It 'should return equal indicators for identical strings' {
+    It 'Should return equal indicators for identical strings' {
         $result = -join (ConvertTo-DifferenceString -ReferenceString 'Hello' -DifferenceString 'Hello')
         $result | Should -Not -Match '!='
     }
 
-    It 'should highlight differences for different strings' {
+    It 'Should highlight differences for different strings' {
         $result = -join (ConvertTo-DifferenceString -ReferenceString 'Hello' -DifferenceString 'Hallo')
         $result | Should -Match '31m65'
         $result | Should -Match '31m61'
@@ -82,19 +82,19 @@ Describe '-join (ConvertTo-DifferenceString' {
         $result | Should -Match '31ma'
     }
 
-    It 'should use custom indicators' {
+    It 'Should use custom indicators' {
         $result = -join (ConvertTo-DifferenceString -ReferenceString 'Hello' -DifferenceString 'Hallo' -EqualIndicator 'EQ' -NotEqualIndicator 'NE')
         $result | Should -Match 'NE'
         $result | Should -Not -Match '=='
         $result | Should -Not -Match '!='
     }
 
-    It 'should handle empty strings' {
+    It 'Should handle empty strings' {
         $result = -join (ConvertTo-DifferenceString -ReferenceString '' -DifferenceString '')
         $result | Should -Not -Match '!='
     }
 
-    It 'should handle different length strings' {
+    It 'Should handle different length strings' {
         $result = -join (ConvertTo-DifferenceString -ReferenceString 'Hello' -DifferenceString 'HelloWorld')
         $result | Should -Match '31mW'
         $result | Should -Match '31mo'
@@ -103,19 +103,19 @@ Describe '-join (ConvertTo-DifferenceString' {
         $result | Should -Match '31md'
     }
 
-    It 'should handle special characters' {
+    It 'Should handle special characters' {
         $result = -join (ConvertTo-DifferenceString -ReferenceString "Hello`n" -DifferenceString "Hello`r")
         $result | Should -Match '31m0A'
         $result | Should -Match '31m0D'
     }
 
-    It 'should use custom highlighting' {
+    It 'Should use custom highlighting' {
         $result = -join (ConvertTo-DifferenceString -ReferenceString 'Hello' -DifferenceString 'Hallo' -HighlightStart "`e[32m" -HighlightEnd "`e[0m")
         $result | Should -Match '32m65'
         $result | Should -Match '32m61'
     }
 
-    It 'should exclude labels and column header' {
+    It 'Should exclude labels and column header' {
         $result = -join (ConvertTo-DifferenceString -ReferenceString 'Hello' -DifferenceString 'Hallo' -NoLabels -NoColumnHeader)
         $result | Should -Not -Match 'Expected:'
         $result | Should -Not -Match 'But was:'
@@ -123,29 +123,29 @@ Describe '-join (ConvertTo-DifferenceString' {
         $result | Should -Not -Match 'Ascii'
     }
 
-    It 'should handle different encodings' {
+    It 'Should handle different encodings' {
         $result = -join (ConvertTo-DifferenceString -ReferenceString 'Hello' -DifferenceString 'Hallo' -EncodingType 'ASCII')
         $result | Should -Match '31m65'
         $result | Should -Match '31m61'
     }
 
-    It 'should handle null reference string' {
+    It 'Should handle null reference string' {
         $result = -join (ConvertTo-DifferenceString -ReferenceString $null -DifferenceString 'Hallo')
         $result | Should -Match '31m48'
     }
 
-    It 'should handle null difference string' {
+    It 'Should handle null difference string' {
         $result = -join (ConvertTo-DifferenceString -ReferenceString 'Hello' -DifferenceString $null)
         $result | Should -Match '31m48'
     }
 
-    It 'should handle escaped characters' {
+    It 'Should handle escaped characters' {
         $result = -join (ConvertTo-DifferenceString -ReferenceString "Hello`tWorld" -DifferenceString "Hello`nWorld")
         $result | Should -Match '31m09'  # Tab character
         $result | Should -Match '31m0A'  # Newline character
     }
 
-    It 'should handle multiple escaped characters' {
+    It 'Should handle multiple escaped characters' {
         $result = -join (ConvertTo-DifferenceString -ReferenceString "Hello`r`nWorld" -DifferenceString "Hello`n`rWorld")
         $result | Should -Match "`e\[31m0D`e\[0m `e\[31m0A`e\[0m"  # Carriage return + Newline
         $result | Should -Match "`e\[31m0A`e\[0m `e\[31m0D`e\[0m"  # Newline + Carriage return

--- a/tests/Unit/Public/Split-StringAtIndex.tests.ps1
+++ b/tests/Unit/Public/Split-StringAtIndex.tests.ps1
@@ -44,19 +44,19 @@ AfterAll {
 
 Describe 'Split-StringAtIndex' {
     Context 'Using StartIndex and EndIndex parameters' {
-        It 'should split the string correctly with valid indices' {
+        It 'Should split the string correctly with valid indices' {
             $result = Split-StringAtIndex -InputString "Hello, World!" -StartIndex 0 -EndIndex 4
 
             $result | Should-BeEquivalent @('Hello', ', World!')
         }
 
-        It 'should handle indices at the end of the string' {
+        It 'Should handle indices at the end of the string' {
             $result = Split-StringAtIndex -InputString "Hello, World!" -StartIndex 7 -EndIndex 11
 
             $result | Should-BeEquivalent @('Hello, ', 'World', '!')
         }
 
-        It 'should return the whole string if indices cover the entire string' {
+        It 'Should return the whole string if indices cover the entire string' {
             $result = Split-StringAtIndex -InputString "Hello, World!" -StartIndex 0 -EndIndex 12
 
             $result | Should-BeEquivalent @('Hello, World!')
@@ -64,7 +64,7 @@ Describe 'Split-StringAtIndex' {
     }
 
     Context 'Using pipeline input with IndexObject' {
-        It 'should split the string correctly with valid index objects' {
+        It 'Should split the string correctly with valid index objects' {
             $indexObjects = @(@{Start = 0; End = 4}, @{Start = 7; End = 11})
 
             $result = $indexObjects | Split-StringAtIndex -InputString "Hello, World!"
@@ -72,7 +72,7 @@ Describe 'Split-StringAtIndex' {
             $result | Should-BeEquivalent @('Hello', ', ', 'World', '!')
         }
 
-        It 'should handle multiple index objects' {
+        It 'Should handle multiple index objects' {
             $indexObjects = @(@{Start = 0; End = 2}, @{Start = 4; End = $null}, @{Start = 8; End = 10})
 
             # cSpell:ignore abcdefghijk
@@ -83,17 +83,17 @@ Describe 'Split-StringAtIndex' {
     }
 
     Context 'Edge cases' {
-        It 'should return the whole string if no indices are provided' {
+        It 'Should return the whole string if no indices are provided' {
             $result = Split-StringAtIndex -InputString "Hello, World!" -StartIndex 0 -EndIndex 12
 
             $result | Should-BeEquivalent @('Hello, World!')
         }
 
-        It 'should handle empty input string' {
+        It 'Should handle empty input string' {
             {  Split-StringAtIndex -InputString "" } | Should -Throw
         }
 
-        It 'should throw an error if indices are out of bounds' {
+        It 'Should throw an error if indices are out of bounds' {
             { Split-StringAtIndex -InputString "Hello" -StartIndex 10 -EndIndex 15 } | Should -Throw
         }
     }


### PR DESCRIPTION

#### Pull Request (PR) description
- `ConvertTo-DifferenceString`
  - Improve how control characters (ASCII values 0-31 and 127) are converted
    to their corresponding Unicode representations in the Control Pictures
    block to output printable versions.

#### This Pull Request (PR) fixes the following issues

None.


#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Documentation added/updated in README.md and source/WikiSource.
- [ ] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where applicable). See
  [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Viscalyx.Common/19)
<!-- Reviewable:end -->
