### PR TITLE
`Invoke-PesterJob`: check for existing Pester module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump action codeql-action/upload-sarif to v4
 - Bump action checkout to v7
+- `Invoke-PesterJob`
+  - Check for existing Pester module before importing.
+  - Support using Pester even if there is no build script.
+
+### Fixed
+
+- `Invoke-PesterJob`
+  - Make sure loop stops after first attempt of running build script to avoid
+    infinite loop when build script fails to install Pester module.
 
 ## [0.7.0] - 2025-09-30
 

--- a/source/Public/Invoke-PesterJob.ps1
+++ b/source/Public/Invoke-PesterJob.ps1
@@ -398,13 +398,6 @@ function Invoke-PesterJob
         try
         {
             $importedPesterModule = Import-Module -Name 'Pester' -MinimumVersion '4.10.1' -ErrorAction 'Stop' -PassThru
-
-            <#
-                Assuming that the project is a Sampler project if the Sampler
-                module is available in the session. Also assuming that a Sampler
-                build task has been run prior to running the command.
-            #>
-            $isSamplerProject = $null -ne (Get-Module -Name 'Sampler')
         }
         catch
         {
@@ -434,6 +427,15 @@ function Invoke-PesterJob
     $pesterModuleVersion = $importedPesterModule | Get-ModuleVersion
 
     Write-Information -MessageData ($script:localizedData.Invoke_PesterJob_UsingImportedPester -f $pesterModuleVersion) -InformationAction 'Continue'
+
+    <#
+        Assuming that the project is a Sampler project if the Sampler
+        module is available in the session. Also assuming that a Sampler
+        build task has been run prior to running the command.
+    #>
+    $isSamplerProject = $null -ne (Get-Module -Name 'Sampler')
+
+    Write-Debug -Message ($script:localizedData.Invoke_PesterJob_Debug_IsSamplerProject -f $isSamplerProject)
 
     # Check for EnableSourceLineMapping requirements
     if ($EnableSourceLineMapping.IsPresent)

--- a/source/Public/Invoke-PesterJob.ps1
+++ b/source/Public/Invoke-PesterJob.ps1
@@ -632,14 +632,14 @@ function Invoke-PesterJob
 
         if ($BuildScriptPath -and (Test-Path -Path $BuildScriptPath))
         {
-            $messageBuildScript = 'Found build script ''{0}''' -f $BuildScriptPath
+            $messageBuildScript = 'Found build script ''{0}''. Running build script inside the job to setup the test pipeline.' -f $BuildScriptPath
+
+            Write-Information -MessageData $messageBuildScript -InformationAction 'Continue'
 
             if ($BuildScriptParameter)
             {
-                $messageBuildScript += ' Running build task ''{0}'' inside the job to setup the test pipeline.' -f $BuildScriptParameter
+                Write-Debug -Message ('Build script parameters: {0}' -f ($BuildScriptParameter | Out-String))
             }
-
-            Write-Information -MessageData $messageBuildScript -InformationAction 'Continue'
 
             $null = & $BuildScriptPath @buildScriptParameter
         }

--- a/source/Public/Invoke-PesterJob.ps1
+++ b/source/Public/Invoke-PesterJob.ps1
@@ -373,22 +373,32 @@ function Invoke-PesterJob
         $BuildScriptParameter = @{ Task = 'noop' }
     )
 
-    if (-not $PSBoundParameters.ContainsKey('BuildScriptPath'))
+    $defaultBuildScriptPath = Join-Path -Path $RootPath -ChildPath 'build.ps1'
+
+    if (-not $PSBoundParameters.ContainsKey('BuildScriptPath') -and (Test-Path -Path $defaultBuildScriptPath -PathType 'Leaf'))
     {
-        $BuildScriptPath = Join-Path -Path $RootPath -ChildPath 'build.ps1'
+        $BuildScriptPath = $defaultBuildScriptPath
     }
 
     $pesterModuleVersion = $null
 
+    $triesCount = 0
+
     do
     {
-        $triesCount = 0
+        $importedPesterModule = Get-Module -Name 'Pester' -ErrorAction 'SilentlyContinue'
+
+        if ($importedPesterModule)
+        {
+            #Write-Information -MessageData $script:localizedData.Invoke_PesterJob_PesterAlreadyImported -InformationAction 'Continue'
+            Write-Information -MessageData 'Pester already imported' -InformationAction 'Continue'
+
+            break
+        }
 
         try
         {
             $importedPesterModule = Import-Module -Name 'Pester' -MinimumVersion '4.10.1' -ErrorAction 'Stop' -PassThru
-
-            $pesterModuleVersion = $importedPesterModule | Get-ModuleVersion
 
             <#
                 Assuming that the project is a Sampler project if the Sampler
@@ -401,7 +411,7 @@ function Invoke-PesterJob
         {
             $triesCount++
 
-            if ($triesCount -eq 1 -and (Test-Path -Path $BuildScriptPath))
+            if ($triesCount -eq 1 -and $BuildScriptPath -and (Test-Path -Path $BuildScriptPath))
             {
                 Write-Information -MessageData 'Could not import Pester. Running build script to make sure required modules is available in session. This can take a few seconds.' -InformationAction 'Continue'
 
@@ -421,6 +431,8 @@ function Invoke-PesterJob
             }
         }
     } until ($importedPesterModule)
+
+    $pesterModuleVersion = $importedPesterModule | Get-ModuleVersion
 
     Write-Information -MessageData ('Using imported Pester v{0}.' -f $pesterModuleVersion) -InformationAction 'Continue'
 

--- a/source/Public/Invoke-PesterJob.ps1
+++ b/source/Public/Invoke-PesterJob.ps1
@@ -380,8 +380,6 @@ function Invoke-PesterJob
         $BuildScriptPath = $defaultBuildScriptPath
     }
 
-    $pesterModuleVersion = $null
-
     $triesCount = 0
 
     do

--- a/source/Public/Invoke-PesterJob.ps1
+++ b/source/Public/Invoke-PesterJob.ps1
@@ -390,8 +390,7 @@ function Invoke-PesterJob
 
         if ($importedPesterModule)
         {
-            #Write-Information -MessageData $script:localizedData.Invoke_PesterJob_PesterAlreadyImported -InformationAction 'Continue'
-            Write-Information -MessageData 'Pester already imported' -InformationAction 'Continue'
+            Write-Debug -Message $script:localizedData.Invoke_PesterJob_PesterAlreadyImported
 
             break
         }
@@ -413,7 +412,7 @@ function Invoke-PesterJob
 
             if ($triesCount -eq 1 -and $BuildScriptPath -and (Test-Path -Path $BuildScriptPath))
             {
-                Write-Information -MessageData 'Could not import Pester. Running build script to make sure required modules is available in session. This can take a few seconds.' -InformationAction 'Continue'
+                Write-Information -MessageData $script:localizedData.Invoke_PesterJob_MissingPesterRunningBuildScript -InformationAction 'Continue'
 
                 # Redirect all streams to $null, except the error stream (stream 2)
                 & $BuildScriptPath @buildScriptParameter 3>&1 4>&1 5>&1 6>&1 > $null
@@ -434,7 +433,7 @@ function Invoke-PesterJob
 
     $pesterModuleVersion = $importedPesterModule | Get-ModuleVersion
 
-    Write-Information -MessageData ('Using imported Pester v{0}.' -f $pesterModuleVersion) -InformationAction 'Continue'
+    Write-Information -MessageData ($script:localizedData.Invoke_PesterJob_UsingImportedPester -f $pesterModuleVersion) -InformationAction 'Continue'
 
     # Check for EnableSourceLineMapping requirements
     if ($EnableSourceLineMapping.IsPresent)
@@ -629,9 +628,23 @@ function Invoke-PesterJob
             $EnableSourceLineMapping
         )
 
-        Write-Information -MessageData 'Running build task ''noop'' inside the job to setup the test pipeline.' -InformationAction 'Continue'
+        if ($BuildScriptPath -and (Test-Path -Path $BuildScriptPath))
+        {
+            $messageBuildScript = 'Found build script ''{0}''' -f $BuildScriptPath
 
-        $null = & $BuildScriptPath @buildScriptParameter
+            if ($BuildScriptParameter)
+            {
+                $messageBuildScript += ' Running build task ''{0}'' inside the job to setup the test pipeline.' -f $BuildScriptParameter
+            }
+
+            Write-Information -MessageData $messageBuildScript -InformationAction 'Continue'
+
+            $null = & $BuildScriptPath @buildScriptParameter
+        }
+        else
+        {
+            Write-Debug -Message 'No build script specified or found. Skipping build script execution inside the job.'
+        }
 
         if ($ShowError.IsPresent)
         {

--- a/source/en-US/Viscalyx.Common.strings.psd1
+++ b/source/en-US/Viscalyx.Common.strings.psd1
@@ -292,6 +292,7 @@ ConvertFrom-StringData @'
     Invoke_PesterJob_PesterAlreadyImported = Pester module is already imported. (IPJ0006)
     Invoke_PesterJob_MissingPesterRunningBuildScript = Could not import Pester. Running build script to make sure required modules is available in session. This can take a few seconds. (IPJ0007)
     Invoke_PesterJob_UsingImportedPester = Using imported Pester v{0}. (IPJ0008)
+    Invoke_PesterJob_Debug_IsSamplerProject = Evaluted to be a Sampler project: {0}. (IPJ0009)
 
     ## Switch-GitLocalBranch
     Switch_GitLocalBranch_FailedCheckoutLocalBranch = Failed to checkout the local branch '{0}'. Make sure the branch exists and is accessible. (SGLB0001)

--- a/source/en-US/Viscalyx.Common.strings.psd1
+++ b/source/en-US/Viscalyx.Common.strings.psd1
@@ -289,6 +289,9 @@ ConvertFrom-StringData @'
     Invoke_PesterJob_AllLinesCoveredFiltered = All lines are covered by tests based on filtering criteria. (IPJ0003)
     Invoke_PesterJob_NoPesterObjectReturned = Unable to determine code coverage result because no Pester object was returned from the test execution. (IPJ0004)
     Invoke_PesterJob_PesterImportFailed = Failed to import Pester module at {0}. (IPJ0005)
+    Invoke_PesterJob_PesterAlreadyImported = Pester module is already imported. (IPJ0006)
+    Invoke_PesterJob_MissingPesterRunningBuildScript = Could not import Pester. Running build script to make sure required modules is available in session. This can take a few seconds. (IPJ0007)
+    Invoke_PesterJob_UsingImportedPester = Using imported Pester v{0}. (IPJ0008)
 
     ## Switch-GitLocalBranch
     Switch_GitLocalBranch_FailedCheckoutLocalBranch = Failed to checkout the local branch '{0}'. Make sure the branch exists and is accessible. (SGLB0001)

--- a/tests/Unit/Public/Disable-CursorShortcutCode.Tests.ps1
+++ b/tests/Unit/Public/Disable-CursorShortcutCode.Tests.ps1
@@ -31,6 +31,9 @@ BeforeAll {
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
     $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+
+    $previousProgressPreference = $ProgressPreference
+    $ProgressPreference = 'SilentlyContinue' # Suppress progress output during deletion
 }
 
 AfterAll {
@@ -40,6 +43,8 @@ AfterAll {
 
     # Unload the module being tested so that it doesn't impact any other tests.
     Get-Module -Name $script:moduleName -All | Remove-Module -Force
+
+    $ProgressPreference = $previousProgressPreference
 }
 
 Describe 'Disable-CursorShortcutCode' {

--- a/tests/Unit/Public/Get-TextOffset.Tests.ps1
+++ b/tests/Unit/Public/Get-TextOffset.Tests.ps1
@@ -83,8 +83,11 @@ The text includes multiple lines.
     }
 
     AfterEach {
+        $previousProgressPreference = $ProgressPreference
+        $ProgressPreference = 'SilentlyContinue' # Suppress progress output during deletion
         # Remove the test file
         Remove-Item -Path $testFilePath -Force
+        $ProgressPreference = $previousProgressPreference
     }
 
     Context 'When the text is found in the file' {

--- a/tests/Unit/Public/Install-ModulePatch.Tests.ps1
+++ b/tests/Unit/Public/Install-ModulePatch.Tests.ps1
@@ -33,7 +33,7 @@ BeforeAll {
     $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
 
     $script:previousProgressPreference = $ProgressPreference
-    $ProgressPreference = 'SilentlyContinue' # Suppress progress output during deletion
+    $ProgressPreference = 'SilentlyContinue' # Suppress progress output during testing
 }
 
 AfterAll {

--- a/tests/Unit/Public/Install-ModulePatch.Tests.ps1
+++ b/tests/Unit/Public/Install-ModulePatch.Tests.ps1
@@ -31,6 +31,9 @@ BeforeAll {
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
     $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+
+    $script:previousProgressPreference = $ProgressPreference
+    $ProgressPreference = 'SilentlyContinue' # Suppress progress output during deletion
 }
 
 AfterAll {
@@ -40,6 +43,8 @@ AfterAll {
 
     # Unload the module being tested so that it doesn't impact any other tests.
     Get-Module -Name $script:moduleName -All | Remove-Module -Force
+
+    $ProgressPreference = $script:previousProgressPreference
 }
 
 Describe 'Install-ModulePatch' {

--- a/tests/Unit/Public/Invoke-PesterJob.Tests.ps1
+++ b/tests/Unit/Public/Invoke-PesterJob.Tests.ps1
@@ -575,6 +575,7 @@ Describe 'Invoke-PesterJob' {
                         {
                             return @{ Version = [version] '5.4.0' }
                         }
+
                         return $null
                     }
                 }


### PR DESCRIPTION

#### Pull Request (PR) description
- `Invoke-PesterJob`
  - Check for existing Pester module before importing.
  - Support using Pester even if there is no build script.
  - Make sure loop stops after first attempt of running build script to avoid
    infinite loop when build script fails to install Pester module.

#### This Pull Request (PR) fixes the following issues

- Fixes #57

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Documentation added/updated in README.md and source/WikiSource.
- [ ] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where applicable). See
  [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Viscalyx.Common/58)
<!-- Reviewable:end -->
